### PR TITLE
Make contributing to docs easier

### DIFF
--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -37,14 +37,18 @@ const config = {
       /** @type {import("@docusaurus/preset-classic").Options} */
       ({
         docs: {
-          sidebarPath: require.resolve("./sidebars.js")
+          sidebarPath: require.resolve("./sidebars.js"),
+          editUrl: ({ docPath }) => {
+            return `https://holocron.so/github/pr/Orange-OpenSource/uuv/main/editor/packages/docs/docs/${docPath}`
+          },
         },
         blog: {
           showReadingTime: true,
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl:
-            "https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/"
+          editUrl: ({ docPath }) => {
+            return `https://holocron.so/github/pr/Orange-OpenSource/uuv/main/editor/packages/docs/docs/${docPath}`
+          },
         },
         theme: {
           customCss: require.resolve("./src/css/custom.css")


### PR DESCRIPTION
With this PR readers can suggest changes to the docs with an easy to use WYSIWYG markdown editor.

[This](https://holocron.so/github/pr/Orange-OpenSource/uuv/main/editor) is how the editor looks like for this repo.

https://github.com/remorses/docusaurus-example/assets/31321188/43c8bc68-3668-4a25-bf1c-a70eceab7bcb